### PR TITLE
✨ `Task` inheritance using a metaclass and `@step` decorator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,6 @@
 
 <!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
 
-- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/davnn/graphtask/blob/main/.github/CODE_OF_CONDUCT.md).
 - [ ] I've read the [`CONTRIBUTING.md`](https://github.com/davnn/graphtask/blob/main/.github/CONTRIBUTING.md) guide.
 - [ ] I've checked the code style using `make submit`.
 - [ ] I've written tests for all new methods and classes that I created.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,10 @@
 name: Check
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   check:

--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">83%</text>
-        <text x="80" y="14">83%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
+        <text x="80" y="14">80%</text>
     </g>
 </svg>

--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
-        <text x="80" y="14">80%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
     </g>
 </svg>

--- a/graphtask/__init__.py
+++ b/graphtask/__init__.py
@@ -3,9 +3,9 @@ Expose public functionality.
 """
 from importlib import metadata as importlib_metadata
 
-from graphtask._task import Task
+from graphtask._task import Task, step
 
-__all__ = ["config", "version", "Task"]
+__all__ = ["config", "version", "Task", "step"]
 
 
 def get_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,13 +158,12 @@ addopts = ["--strict-markers", "--tb=short"]
 
 [tool.coverage.run]
 source = ["tests"]
-
-[coverage.paths]
-source = "graphtask"
-
-[coverage.run]
 branch = true
 
-[coverage.report]
-fail_under = 80
+[tool.coverage.paths]
+source = ["graphtask"]
+
+[tool.coverage.report]
+fail_under = 90
 show_missing = true
+exclude_lines = ["pragma: no cover", "@overload"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,34 @@
+from hypothesis import strategies as s
+
+max_container_size = 3
+
+# values of basic types
+text = s.text()
+binary = s.binary()
+ints = s.integers()
+floats = s.floats(allow_nan=False)
+complexes = s.complex_numbers(allow_nan=False)
+boolean = s.booleans()
+nones = s.none()
+basics = s.one_of([text, binary, ints, floats, complexes, boolean, nones])
+
+# sequences of basic types
+create_list = lambda strategy: s.lists(strategy, max_size=max_container_size)
+create_set = lambda strategy: s.sets(strategy, max_size=max_container_size)
+create_tuple = lambda strategy: s.one_of([s.tuples(*([strategy] * i)) for i in range(max_container_size)])
+create_dict = lambda strategy, keys=text: s.dictionaries(keys=keys, values=strategy, max_size=max_container_size)
+basic_containers = [create_list(basics), create_set(basics), create_tuple(basics), create_dict(basics)]
+lists, sets, tuples, dicts = basic_containers
+sequences = s.one_of(basic_containers)  # these all have a length defined
+
+# iterables of basic types
+create_iterable = lambda strategy: s.iterables(strategy, max_size=max_container_size)
+iterables = create_iterable(basics)
+
+# any value is valid
+anything = s.one_of([basics, sequences, iterables])
+
+# context dependant strategies
+int_gt_1_lt_max = s.integers(min_value=2, max_value=max_container_size)
+list_of_iterables = create_list(iterables)
+dict_of_iterables = create_dict(iterables)

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,26 @@
+"""
+Test the representation of a `Task`
+"""
+from graphtask import Task
+
+
+def test_str():
+    task = Task()
+    assert str(task) == "Task(n_jobs=1)"
+
+
+def test_repr():
+    # empty nodes
+    task = Task()
+    assert repr(task) == str(task)
+
+    # nodes without edges
+    task = Task()
+    task.register(a=1, b=2)
+    assert repr(task) == "Task(n_jobs=1)\no    a,b"
+
+    # nodes and edges
+    task = Task()
+    task.register(a=1)
+    task.step(fn=lambda a: a, rename="b")
+    assert repr(task) == "Task(n_jobs=1)\no    a\n|\no    b"

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,0 +1,190 @@
+"""
+Test the equivalence of `step` and the `@step` decorator.
+"""
+from hypothesis import given
+
+from graphtask import Task, step
+from tests import *
+
+
+@given(a=ints, b=ints, c=ints, d=ints)
+def test_fn_signatures(a, b, c, d):
+    def fn1(a, b, c, d):
+        return a + b * c + d
+
+    def fn2(*, a, b, c, d):
+        return a + b * c + d
+
+    def fn3(a, b, *, c, d):
+        return a + b * c + d
+
+    def fn4(a, b, c, d, /):
+        return a + b * c + d
+
+    def fn5(a, b, /, c, d):
+        return a + b * c + d
+
+    def fn6(a, /, b, *, c, d):
+        return a + b * c + d
+
+    def fn7(a, b, /, c, *, d):
+        return a + b * c + d
+
+    def fn8(a, b, /, *, c, d):
+        return a + b * c + d
+
+    def fn9(a, /, b, *c, **d):
+        return a + b * c[0] + list(d.values())[0]
+
+    def fn10(a, b, /, *c, **d):
+        return a + b * c[0] + list(d.values())[0]
+
+    def fn11(a, /, *c, b, **d):
+        return a + b * c[0] + list(d.values())[0]
+
+    task = Task()
+    task.register(a=a, b=b, c=c, d=d)
+    for fn in [fn1, fn2, fn3, fn4, fn5, fn6, fn7, fn8, fn9, fn10, fn11]:
+        task.step(fn=fn, args=["c"], kwargs=["d"])
+
+    for result in task.run():
+        assert a + b * c + d == result
+
+
+@given(a=ints, b=ints, c=ints, d=ints)
+def test_decorator_signatures(a, b, c, d):
+    task = Task()
+    task.register(a=a, b=b, c=c, d=d)
+
+    @task.step
+    def fn1(a, b, c, d):
+        return a + b * c + d
+
+    @task.step
+    def fn2(*, a, b, c, d):
+        return a + b * c + d
+
+    @task.step
+    def fn3(a, b, *, c, d):
+        return a + b * c + d
+
+    @task.step
+    def fn4(a, b, c, d, /):
+        return a + b * c + d
+
+    @task.step
+    def fn5(a, b, /, c, d):
+        return a + b * c + d
+
+    @task.step
+    def fn6(a, /, b, *, c, d):
+        return a + b * c + d
+
+    @task.step
+    def fn7(a, b, /, c, *, d):
+        return a + b * c + d
+
+    @task.step
+    def fn8(a, b, /, *, c, d):
+        return a + b * c + d
+
+    @task.step(args=["c"], kwargs=["d"])
+    def fn9(a, /, b, *c, **d):
+        return a + b * c[0] + list(d.values())[0]
+
+    @task.step(args=["c"], kwargs=["d"])
+    def fn10(a, b, /, *c, **d):
+        return a + b * c[0] + list(d.values())[0]
+
+    @task.step(args=["c"], kwargs=["d"])
+    def fn11(a, /, *c, b, **d):
+        return a + b * c[0] + list(d.values())[0]
+
+    for result in task.run():
+        assert a + b * c + d == result
+
+
+@given(a=ints, b=ints, c=ints, d=ints)
+def test_method_signatures(a, b, c, d):
+    class T(Task):
+        @step
+        def fn1(self, a, b, c, d):
+            return a + b * c + d
+
+        @step
+        def fn2(self, *, a, b, c, d):
+            return a + b * c + d
+
+        @step
+        def fn3(self, a, b, *, c, d):
+            return a + b * c + d
+
+        @step
+        def fn4(self, a, b, c, d, /):
+            return a + b * c + d
+
+        @step
+        def fn5(self, a, b, /, c, d):
+            return a + b * c + d
+
+        @step
+        def fn6(self, a, /, b, *, c, d):
+            return a + b * c + d
+
+        @step
+        def fn7(self, a, b, /, c, *, d):
+            return a + b * c + d
+
+        @step
+        def fn8(self, a, b, /, *, c, d):
+            return a + b * c + d
+
+        @step(args=["c"], kwargs=["d"])
+        def fn9(self, a, /, b, *c, **d):
+            return a + b * c[0] + list(d.values())[0]
+
+        @step(args=["c"], kwargs=["d"])
+        def fn10(self, a, b, /, *c, **d):
+            return a + b * c[0] + list(d.values())[0]
+
+        @step(args=["c"], kwargs=["d"])
+        def fn11(self, a, /, *c, b, **d):
+            return a + b * c[0] + list(d.values())[0]
+
+    task = T()
+    task.register(a=a, b=b, c=c, d=d)
+    for result in task.run():
+        assert a + b * c + d == result
+
+
+@given(data=basics)
+def test_equivalence(data):
+    """Test if different syntactic approaches yield the same result"""
+
+    # functional approach
+    task_fun = Task()
+
+    def identity(data):
+        return data
+
+    task_fun.register(data=data)
+    task_fun.step(fn=identity)
+
+    # decorator approach
+    task_dec = Task()
+    task_dec.register(data=data)
+
+    @task_dec.step
+    def identity(data):
+        return data
+
+    # class approach
+    class T(Task):
+        @step
+        def identity(self, data):
+            return data
+
+    task_cls = T()
+    task_cls.register(data=data)
+
+    assert task_fun.run() == task_dec.run() == task_cls.run()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,3 +1,7 @@
+"""
+Test the functionality of a `Task`
+"""
+
 import pytest
 from hypothesis import given
 from hypothesis import strategies as s
@@ -114,9 +118,6 @@ def test_step_assertions():
 
     with pytest.raises(AssertionError, match="Cannot name node '<lambda>'"):
         task.step(fn=lambda: None)
-
-    with pytest.raises(AssertionError, match="Cannot find 'x' in the graph"):
-        task.step(fn=fn)
 
     with pytest.raises(AssertionError, match="Cannot verify that predicate 'is_dag' holds"):
         task.step(lambda: None, rename="cyclic")


### PR DESCRIPTION
## Description

It is now possible to inherit from `Task` and add methods as steps using `graphtask.@step`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x ] 🔧 Bug fix
- [ x ] 🚀 Improvement / New feature
